### PR TITLE
Add `line-break` CSS property

### DIFF
--- a/src/list.ts
+++ b/src/list.ts
@@ -117,6 +117,7 @@ export const PROPERTY_LIST = [
     "left",
     "letter-spacing",
     "line-clamp",
+    "line-break",
     "line-height",
     "list-style-position",
     "list-style-type",


### PR DESCRIPTION
The line-break CSS property sets how to break lines of Chinese, Japanese, or Korean (CJK) text when working with punctuation and symbols.