### PR TITLE
Add `writing-mode` CSS property

### DIFF
--- a/src/list.ts
+++ b/src/list.ts
@@ -178,6 +178,7 @@ export const PROPERTY_LIST = [
     "white-space",
     "width",
     "word-break",
+    "writing-mode",
     "z-index",
 ];
 export const PROPERTY_VARIANTS = {


### PR DESCRIPTION
The writing-mode CSS property sets whether lines of text are laid out horizontally or vertically, as well as the direction in which blocks progress.

Docs: https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode